### PR TITLE
vocabulary: check for exact match against discrete answers

### DIFF
--- a/src/components/VocabularyQuiz.js
+++ b/src/components/VocabularyQuiz.js
@@ -57,9 +57,8 @@ class VocabularyQuiz extends Component {
   handleChange(e) {
     const val = e.target.value.toLowerCase();
     const { currentWord } = this.state;
-    const pattern = new RegExp(currentWord.matches);
-
-    if (pattern.test(val)) {
+    
+    if (currentWord.answers.includes(val)) {
       const remainingCharacters = this.state.words.slice(1);
       return this.setState({
         words: remainingCharacters,

--- a/src/lib/adjectives.json
+++ b/src/lib/adjectives.json
@@ -4,163 +4,163 @@
       "hiragana": "おおきい",
       "romaji": "ookii",
       "english": "big",
-      "matches": "big|large"
+      "answers": ["big", "large"]
     },
     {
       "hiragana": "ちいさい",
       "romaji": "chiisai",
       "english": "small",
-      "matches": "small|little"
+      "answers": ["small", "little"]
     },
     {
       "hiragana": "いい",
       "romaji": "ii",
       "english": "good",
-      "matches": "good"
+      "answers": ["good"]
     },
     {
       "hiragana": "わるい",
       "romaji": "warui",
       "english": "bad",
-      "matches": "bad"
+      "answers": ["bad"]
     },
     {
       "hiragana": "すごい",
       "romaji": "sugoi",
       "english": "great",
-      "matches": "great|amazing|good"
+      "answers": ["great", "amazing", "good"]
     },
     {
       "hiragana": "あたらしい",
       "romaji": "atarashii",
       "english": "new",
-      "matches": "new"
+      "answers": ["new"]
     },
     {
       "hiragana": "ふるい",
       "romaji": "furui",
       "english": "old",
-      "matches": "old"
+      "answers": ["old"]
     },
     {
       "hiragana": "さむい",
       "romaji": "samui",
       "english": "cold",
-      "matches": "cold"
+      "answers": ["cold"]
     },
     {
       "hiragana": "あつい",
       "romaji": "atsui",
       "english": "hot",
-      "matches": "hot"
+      "answers": ["hot"]
     },
     {
       "hiragana": "かっこいい",
       "romaji": "kakkoii",
       "english": "cool",
-      "matches": "cool"
+      "answers": ["cool"]
     },
     {
       "hiragana": "たかい",
       "romaji": "takai",
       "english": "expensive",
-      "matches": "expensive"
+      "answers": ["expensive"]
     },
     {
       "hiragana": "やすい",
       "romaji": "yasui",
       "english": "cheap",
-      "matches": "cheap"
+      "answers": ["cheap"]
     },
     {
       "hiragana": "きたない",
       "romaji": "kitanai",
       "english": "dirty",
-      "matches": "dirty"
+      "answers": ["dirty"]
     },
     {
       "hiragana": "たのしい",
       "romaji": "tanoshii",
       "english": "fun",
-      "matches": "fun"
+      "answers": ["fun"]
     },
     {
       "hiragana": "つまらない",
       "romaji": "tsumaranai",
       "english": "boring",
-      "matches": "boring"
+      "answers": ["boring"]
     },
     {
       "hiragana": "やさしい",
       "romaji": "yasashii",
       "english": "easy",
-      "matches": "easy"
+      "answers": ["easy"]
     },
     {
       "hiragana": "むずかしい",
       "romaji": "muzukashii",
       "english": "dificult",
-      "matches": "dificult"
+      "answers": ["dificult"]
     },
     {
       "hiragana": "おもしろい",
       "romaji": "omoshiroi",
       "english": "interesting",
-      "matches": "interesting"
+      "answers": ["interesting"]
     },
     {
       "hiragana": "いそがしい",
       "romaji": "isogashii",
       "english": "busy",
-      "matches": "busy"
+      "answers": ["busy"]
     },
     {
       "hiragana": "こわい",
       "romaji": "kowai",
       "english": "scary",
-      "matches": "scary"
+      "answers": ["scary"]
     },
     {
       "hiragana": "きれい(な)",
       "romaji": "kirei",
       "english": "pretty",
-      "matches": "pretty"
+      "answers": ["pretty"]
     },
     {
       "hiragana": "しずか(な)",
       "romaji": "shizuka",
       "english": "quiet",
-      "matches": "quiet"
+      "answers": ["quiet"]
     },
     {
       "hiragana": "にぎやか(な)",
       "romaji": "nigiyaka",
       "english": "lively",
-      "matches": "lively"
+      "answers": ["lively"]
     },
     {
       "hiragana": "げんき(な)",
       "romaji": "genki",
       "english": "happy",
-      "matches": "happy"
+      "answers": ["happy"]
     },
     {
       "hiragana": "すき(な)",
       "romaji": "suki",
       "english": "like",
-      "matches": "like"
+      "answers": ["like"]
     },
     {
       "hiragana": "きらい(な)",
       "romaji": "kirai",
       "english": "dislike",
-      "matches": "dislike"
+      "answers": ["dislike"]
     },
     {
       "hiragana": "ひま(な)",
       "romaji": "hima",
       "english": "free",
-      "matches": "free"
+      "answers": ["free"]
     }
   ]
 }

--- a/src/lib/verbs.json
+++ b/src/lib/verbs.json
@@ -4,85 +4,85 @@
       "hiragana": "たべる",
       "romaji": "taberu",
       "english": "to eat",
-      "matches": "eat"
+      "answers": ["eat"]
     },
     {
       "hiragana": "のむ",
       "romaji": "nomu",
       "english": "to drink",
-      "matches": "drink"
+      "answers": ["drink"]
     },
     {
       "hiragana": "わかる",
       "romaji": "wakaru",
       "english": "to understand",
-      "matches": "understand"
+      "answers": ["understand"]
     },
     {
       "hiragana": "みる",
       "romaji": "miru",
       "english": "to see",
-      "matches": "see|watch|look"
+      "answers": ["see", "watch", "look"]
     },
     {
       "hiragana": "ねる",
       "romaji": "neru",
       "english": "to sleep",
-      "matches": "sleep"
+      "answers": ["sleep"]
     },
     {
       "hiragana": "おきる",
       "romaji": "okiru",
       "english": "to wake up",
-      "matches": "wake|occur"
+      "answers": ["wake", "occur"]
     },
     {
       "hiragana": "きる",
       "romaji": "kiru",
       "english": "to wear",
-      "matches": "wear"
+      "answers": ["wear"]
     },
     {
       "hiragana": "はなす",
       "romaji": "hanasu",
       "english": "to speak",
-      "matches": "speak|say"
+      "answers": ["speak", "say"]
     },
     {
       "hiragana": "きく",
       "romaji": "kiku",
       "english": "to ask or listen",
-      "matches": "listen|ask"
+      "answers": ["listen", "ask"]
     },
     {
       "hiragana": "およぐ",
       "romaji": "oyogu",
       "english": "to swim",
-      "matches": "swim"
+      "answers": ["swim"]
     },
     {
       "hiragana": "まつ",
       "romaji": "matsu",
       "english": "to wait",
-      "matches": "wait"
+      "answers": ["wait"]
     },
     {
       "hiragana": "かう",
       "romaji": "kau",
       "english": "to buy",
-      "matches": "buy"
+      "answers": ["buy"]
     },
     {
       "hiragana": "くる",
       "romaji": "kuru",
       "english": "to come",
-      "matches": "come"
+      "answers": ["come"]
     },
     {
       "hiragana": "かえる",
       "romaji": "kaeru",
       "english": "to return home",
-      "matches": "(go home)|(return home)"
+      "answers": ["go home", "return home"]
     }
   ],
   "basic_more": [
@@ -90,115 +90,115 @@
       "hiragana": "あける",
       "romaji": "akeru",
       "english": "to open",
-      "matches": "open"
+      "answers": ["open"]
     },
     {
       "hiragana": "おしえる",
       "romaji": "oshieru",
       "english": "to teach",
-      "matches": "teach"
+      "answers": ["teach"]
     },
     {
       "hiragana": "おりる",
       "romaji": "oriru",
       "english": "to get off",
-      "matches": "get off"
+      "answers": ["get off"]
     },
     {
       "hiragana": "かりる",
       "romaji": "kariru",
       "english": "to borrow",
-      "matches": "borrow"
+      "answers": ["borrow"]
     },
     {
       "hiragana": "しめる",
       "romaji": "shimeru",
       "english": "to close",
-      "matches": "close"
+      "answers": ["close"]
     },
     {
       "hiragana": "つける",
       "romaji": "tsukeru",
       "english": "to put on",
-      "matches": "(put on)|(turn on)"
+      "answers": ["put on", "turn on"]
     },
     {
       "hiragana": "わすれる",
       "romaji": "wasureru",
       "english": "to forget",
-      "matches": "forget"
+      "answers": ["forget"]
     },
     {
       "hiragana": "つかう",
       "romaji": "tsukau",
       "english": "to use",
-      "matches": "use"
+      "answers": ["use"]
     },
     {
       "hiragana": "てつだう",
       "romaji": "tetsudau",
       "english": "to help",
-      "matches": "help"
+      "answers": ["help"]
     },
     {
       "hiragana": "いそぐ",
       "romaji": "isogu",
       "english": "to hurry",
-      "matches": "hurry"
+      "answers": ["hurry"]
     },
     {
       "hiragana": "かえす",
       "romaji": "kaesu",
       "english": "to return",
-      "matches": "return"
+      "answers": ["return"]
     },
     {
       "hiragana": "けす",
       "romaji": "kesu",
       "english": "to turn off",
-      "matches": "turn off"
+      "answers": ["turn off"]
     },
     {
       "hiragana": "たつ",
       "romaji": "tatsu",
       "english": "to stand up",
-      "matches": "(stand up)|rise"
+      "answers": ["stand up", "rise"]
     },
     {
       "hiragana": "はこぶ",
       "romaji": "hakobu",
       "english": "to carry",
-      "matches": "carry"
+      "answers": ["carry"]
     },
     {
       "hiragana": "しぬ",
       "romaji": "shinu",
       "english": "to die",
-      "matches": "die"
+      "answers": ["die"]
     },
     {
       "hiragana": "あそぶ",
       "romaji": "asobu",
       "english": "to play",
-      "matches": "play"
+      "answers": ["play"]
     },
     {
       "hiragana": "やすむ",
       "romaji": "yasumu",
       "english": "to be absent",
-      "matches": "absent|rest"
+      "answers": ["absent", "rest"]
     },
     {
       "hiragana": "すわる",
       "romaji": "suwaru",
       "english": "to sit",
-      "matches": "sit"
+      "answers": ["sit"]
     },
     {
       "hiragana": "はいる",
       "romaji": "hairu",
       "english": "to enter",
-      "matches": "enter"
+      "answers": ["enter"]
     }
   ]
 }

--- a/src/lib/weekdays.json
+++ b/src/lib/weekdays.json
@@ -5,49 +5,49 @@
       "hiragana": "げつようび",
       "romaji": "getsuyōbi",
       "english": "monday",
-      "matches": "monday"
+      "answers": ["monday"]
     },
     {
       "kanji": "火曜日",
       "hiragana": "かようび",
       "romaji": "kayōbi",
       "english": "tuesday",
-      "matches": "tuesday"
+      "answers": ["tuesday"]
     },
     {
       "kanji": "水曜日",
       "hiragana": "すいようび",
       "romaji": "suiyōbi",
       "english": "wednesday",
-      "matches": "wednesday"
+      "answers": ["wednesday"]
     },
     {
       "kanji": "木曜日",
       "hiragana": "もくようび",
       "romaji": "mokuyōbi",
       "english": "thursday",
-      "matches": "thursday"
+      "answers": ["thursday"]
     },
     {
       "kanji": "金曜日",
       "hiragana": "きんようび",
       "romaji": "kinyōbi",
       "english": "friday",
-      "matches": "friday"
+      "answers": ["friday"]
     },
     {
       "kanji": "土曜日",
       "hiragana": "どようび",
       "romaji": "doyōbi",
       "english": "saturday",
-      "matches": "saturday"
+      "answers": ["saturday"]
     },
     {
       "kanji": "日曜日",
       "hiragana": "にちようび",
       "romaji": "nichiyōbi",
       "english": "sunday",
-      "matches": "sunday"
+      "answers": ["sunday"]
     }
   ],
   "resources": ["https://nipponrama.com/days-week-japanese/"]


### PR DESCRIPTION
Make vocabulary quiz answers discrete values so the submission value must exactly match an answer before it is accepted. Without this change, "ASBSDF*cold*12314" matches "cold".